### PR TITLE
Add input validation, pre-commit, mypy baseline, and CHANGELOG

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Run: pip install pre-commit && pre-commit install
+# Docs: https://pre-commit.com
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        files: ^src/
+        additional_dependencies:
+          - httpx>=0.27.0
+          - python-dotenv>=1.0.0
+          - mcp>=1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to **NetLicensing MCP Server** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Version numbers are derived from Git tags via `hatch-vcs`.
+
+## [Unreleased]
+
+### Added
+- Input validation for identifiers, emails, currency codes, ISO-8601 dates,
+  license types, licensing models, and enum-style fields at the tool boundary.
+- `NETLICENSING_HTTP_TIMEOUT` and `NETLICENSING_HTTP_CONNECT_TIMEOUT` environment
+  variables to override HTTP client timeouts.
+- `[tool.mypy]` baseline configuration in `pyproject.toml`.
+- `.pre-commit-config.yaml` with ruff, mypy, and sanity hooks.
+- `CHANGELOG.md`.
+
+### Changed
+- Tool arguments with known formats (emails, currency, dates, enums) are now
+  rejected early with a user-friendly error rather than a raw HTTP 4xx.
+
+## [0.x] — prior releases
+
+See the Git history and GitHub releases:
+https://github.com/Labs64/NetLicensing-MCP/releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,17 @@ omit = ["tests/*"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+
+# Baseline mypy config: keep the existing default-level checks (which already
+# pass cleanly). Raising the baseline to strict mode would surface dozens of
+# pre-existing issues in the tool wrappers and is better tackled as a
+# separate cleanup pass.
+[tool.mypy]
+python_version = "3.12"
+pretty = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["mcp.*"]
+ignore_missing_imports = true
+

--- a/src/netlicensing_mcp/client.py
+++ b/src/netlicensing_mcp/client.py
@@ -30,6 +30,21 @@ api_key_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
     "api_key", default=os.getenv("NETLICENSING_API_KEY", "")
 )
 
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("%s=%r is not a number — using default %s", name, raw, default)
+        return default
+
+
+HTTP_TIMEOUT: float = _float_env("NETLICENSING_HTTP_TIMEOUT", 30.0)
+HTTP_CONNECT_TIMEOUT: float = _float_env("NETLICENSING_HTTP_CONNECT_TIMEOUT", 10.0)
+
 # ── Error wrapper ────────────────────────────────────────────────────────────
 
 
@@ -85,7 +100,7 @@ def _get_client() -> httpx.AsyncClient:
     global _client  # noqa: PLW0603
     if _client is None or _client.is_closed:
         _client = httpx.AsyncClient(
-            timeout=httpx.Timeout(30.0, connect=10.0),
+            timeout=httpx.Timeout(HTTP_TIMEOUT, connect=HTTP_CONNECT_TIMEOUT),
             limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
         )
     return _client

--- a/src/netlicensing_mcp/server.py
+++ b/src/netlicensing_mcp/server.py
@@ -22,6 +22,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from netlicensing_mcp import validation as v
 from netlicensing_mcp.client import NetLicensingError
 from netlicensing_mcp.prompts.audit import register_audit_prompts
 from netlicensing_mcp.tools import (
@@ -36,6 +37,7 @@ from netlicensing_mcp.tools import (
     transactions,
     utilities,
 )
+from netlicensing_mcp.validation import ValidationError
 
 # Configure logging to output to stdout
 logging.basicConfig(
@@ -147,6 +149,14 @@ def _error(exc: NetLicensingError) -> str:
     return json.dumps({"error": True, "status": exc.status_code, "detail": exc.detail}, indent=2)
 
 
+def _validation_error(exc: ValidationError) -> str:
+    """Return a user-friendly JSON error for a client-side validation failure."""
+    return json.dumps(
+        {"error": True, "validation": True, "field": exc.field, "detail": exc.message},
+        indent=2,
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # PRODUCTS
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -173,7 +183,10 @@ async def netlicensing_get_product(product_number: str) -> str:
         product_number: Product identifier (e.g. 'P001')
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
         return _json(await products.get_product(product_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -204,6 +217,11 @@ async def netlicensing_create_product(
         licensee_secret_mode: DISABLED, PREDEFINED, or CLIENT (leave empty for default)
     """
     try:
+        number = v.identifier(number, "number")
+        if vat_mode:
+            vat_mode = v.vat_mode(vat_mode)
+        if licensee_secret_mode:
+            licensee_secret_mode = v.licensee_secret_mode(licensee_secret_mode)
         return _json(
             await products.create_product(
                 number,
@@ -217,6 +235,8 @@ async def netlicensing_create_product(
                 licensee_secret_mode=licensee_secret_mode or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -247,6 +267,11 @@ async def netlicensing_update_product(
         licensee_secret_mode: DISABLED, PREDEFINED, or CLIENT (leave empty to keep current)
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
+        if vat_mode:
+            vat_mode = v.vat_mode(vat_mode)
+        if licensee_secret_mode:
+            licensee_secret_mode = v.licensee_secret_mode(licensee_secret_mode)
         return _json(
             await products.update_product(
                 product_number,
@@ -260,6 +285,8 @@ async def netlicensing_update_product(
                 licensee_secret_mode=licensee_secret_mode or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -273,7 +300,10 @@ async def netlicensing_delete_product(product_number: str, force_cascade: bool =
         force_cascade: Also delete all dependent modules, templates, licensees, and licenses
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
         return await products.delete_product(product_number, force_cascade)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -300,7 +330,10 @@ async def netlicensing_get_bundle(bundle_number: str) -> str:
         bundle_number: Bundle identifier (e.g. 'B001')
     """
     try:
+        bundle_number = v.identifier(bundle_number, "bundle_number")
         return _json(await bundles.get_bundle(bundle_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -327,6 +360,13 @@ async def netlicensing_create_bundle(
         description: Optional bundle description
     """
     try:
+        number = v.identifier(number, "number")
+        license_template_numbers = [
+            v.identifier(t, "license_template_numbers[]") for t in license_template_numbers
+        ]
+        if price is not None:
+            v.non_negative_number(price, "price")
+        normalized_currency = v.currency(currency) if currency else None
         return _json(
             await bundles.create_bundle(
                 number,
@@ -334,10 +374,12 @@ async def netlicensing_create_bundle(
                 license_template_numbers,
                 active,
                 price=price,
-                currency=currency or None,
+                currency=normalized_currency,
                 description=description,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -364,6 +406,14 @@ async def netlicensing_update_bundle(
         description: New description (leave empty to keep current)
     """
     try:
+        bundle_number = v.identifier(bundle_number, "bundle_number")
+        if license_template_numbers is not None:
+            license_template_numbers = [
+                v.identifier(t, "license_template_numbers[]") for t in license_template_numbers
+            ]
+        if price is not None:
+            v.non_negative_number(price, "price")
+        normalized_currency = v.currency(currency) if currency else None
         return _json(
             await bundles.update_bundle(
                 bundle_number,
@@ -371,10 +421,12 @@ async def netlicensing_update_bundle(
                 active,
                 license_template_numbers,
                 price,
-                currency or None,
+                normalized_currency,
                 description or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -388,7 +440,10 @@ async def netlicensing_delete_bundle(bundle_number: str, force_cascade: bool = F
         force_cascade: Force deletion even if dependencies exist
     """
     try:
+        bundle_number = v.identifier(bundle_number, "bundle_number")
         return await bundles.delete_bundle(bundle_number, force_cascade)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -406,7 +461,11 @@ async def netlicensing_obtain_bundle(
         licensee_number: Customer (licensee) who receives the licenses
     """
     try:
+        bundle_number = v.identifier(bundle_number, "bundle_number")
+        licensee_number = v.identifier(licensee_number, "licensee_number")
         return _json(await bundles.obtain_bundle(bundle_number, licensee_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -425,12 +484,15 @@ async def netlicensing_list_product_modules(product_number: str, filter: str = "
         filter: Optional server-side filter expression (e.g. 'active=true')
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
         return _json(
             await product_modules.list_product_modules(
                 product_number,
                 filter_str=filter or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -443,7 +505,10 @@ async def netlicensing_get_product_module(module_number: str) -> str:
         module_number: Module identifier
     """
     try:
+        module_number = v.identifier(module_number, "module_number")
         return _json(await product_modules.get_product_module(module_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -475,6 +540,18 @@ async def netlicensing_create_product_module(
         node_secret_mode: PREDEFINED or CLIENT (NodeLocked model)
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
+        number = v.identifier(number, "number")
+        licensing_model = v.licensing_model(licensing_model)
+        if max_checkout_validity is not None:
+            v.positive_int(max_checkout_validity, "max_checkout_validity")
+        if yellow_threshold is not None:
+            v.positive_int(yellow_threshold, "yellow_threshold", allow_zero=True)
+        if red_threshold is not None:
+            v.positive_int(red_threshold, "red_threshold", allow_zero=True)
+        normalized_node_secret_mode = (
+            v.node_secret_mode(node_secret_mode) if node_secret_mode else None
+        )
         return _json(
             await product_modules.create_product_module(
                 product_number,
@@ -485,9 +562,11 @@ async def netlicensing_create_product_module(
                 max_checkout_validity=max_checkout_validity,
                 yellow_threshold=yellow_threshold,
                 red_threshold=red_threshold,
-                node_secret_mode=node_secret_mode or None,
+                node_secret_mode=normalized_node_secret_mode,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -514,6 +593,16 @@ async def netlicensing_update_product_module(
         node_secret_mode: PREDEFINED or CLIENT (NodeLocked model, leave empty to keep current)
     """
     try:
+        module_number = v.identifier(module_number, "module_number")
+        if max_checkout_validity is not None:
+            v.positive_int(max_checkout_validity, "max_checkout_validity")
+        if yellow_threshold is not None:
+            v.positive_int(yellow_threshold, "yellow_threshold", allow_zero=True)
+        if red_threshold is not None:
+            v.positive_int(red_threshold, "red_threshold", allow_zero=True)
+        normalized_node_secret_mode = (
+            v.node_secret_mode(node_secret_mode) if node_secret_mode else None
+        )
         return _json(
             await product_modules.update_product_module(
                 module_number,
@@ -522,9 +611,11 @@ async def netlicensing_update_product_module(
                 max_checkout_validity=max_checkout_validity,
                 yellow_threshold=yellow_threshold,
                 red_threshold=red_threshold,
-                node_secret_mode=node_secret_mode or None,
+                node_secret_mode=normalized_node_secret_mode,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -540,7 +631,10 @@ async def netlicensing_delete_product_module(
         force_cascade: Also delete all dependent license templates and licenses
     """
     try:
+        module_number = v.identifier(module_number, "module_number")
         return await product_modules.delete_product_module(module_number, force_cascade)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -559,12 +653,15 @@ async def netlicensing_list_license_templates(module_number: str, filter: str = 
         filter: Optional server-side filter expression (e.g. 'active=true')
     """
     try:
+        module_number = v.identifier(module_number, "module_number")
         return _json(
             await license_templates.list_license_templates(
                 module_number,
                 filter_str=filter or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -577,7 +674,10 @@ async def netlicensing_get_license_template(template_number: str) -> str:
         template_number: Template identifier
     """
     try:
+        template_number = v.identifier(template_number, "template_number")
         return _json(await license_templates.get_license_template(template_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -620,6 +720,18 @@ async def netlicensing_create_license_template(
         grace_period: Allow grace period after expiry (Subscription model)
     """
     try:
+        module_number = v.identifier(module_number, "module_number")
+        number = v.identifier(number, "number")
+        license_type = v.license_type(license_type)
+        currency = v.currency(currency)
+        v.non_negative_number(price, "price")
+        if time_volume is not None:
+            v.positive_int(time_volume, "time_volume")
+        normalized_period = v.time_volume_period(time_volume_period) if time_volume_period else None
+        if max_sessions is not None:
+            v.positive_int(max_sessions, "max_sessions")
+        if quantity is not None:
+            v.positive_int(quantity, "quantity")
         return _json(
             await license_templates.create_license_template(
                 module_number,
@@ -633,12 +745,14 @@ async def netlicensing_create_license_template(
                 hidden=hidden,
                 hide_licenses=hide_licenses,
                 time_volume=time_volume,
-                time_volume_period=time_volume_period or None,
+                time_volume_period=normalized_period,
                 max_sessions=max_sessions,
                 quantity=quantity,
                 grace_period=grace_period,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -677,23 +791,36 @@ async def netlicensing_update_license_template(
         grace_period: Grace period after expiry — Subscription model (omit to keep current)
     """
     try:
+        template_number = v.identifier(template_number, "template_number")
+        normalized_currency = v.currency(currency) if currency else None
+        if price is not None:
+            v.non_negative_number(price, "price")
+        if time_volume is not None:
+            v.positive_int(time_volume, "time_volume")
+        normalized_period = v.time_volume_period(time_volume_period) if time_volume_period else None
+        if max_sessions is not None:
+            v.positive_int(max_sessions, "max_sessions")
+        if quantity is not None:
+            v.positive_int(quantity, "quantity")
         return _json(
             await license_templates.update_license_template(
                 template_number,
                 name or None,
                 active,
                 price,
-                currency=currency or None,
+                currency=normalized_currency,
                 automatic=automatic,
                 hidden=hidden,
                 hide_licenses=hide_licenses,
                 time_volume=time_volume,
-                time_volume_period=time_volume_period or None,
+                time_volume_period=normalized_period,
                 max_sessions=max_sessions,
                 quantity=quantity,
                 grace_period=grace_period,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -709,7 +836,10 @@ async def netlicensing_delete_license_template(
         force_cascade: Also delete all dependent licenses
     """
     try:
+        template_number = v.identifier(template_number, "template_number")
         return await license_templates.delete_license_template(template_number, force_cascade)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -728,12 +858,15 @@ async def netlicensing_list_licensees(product_number: str, filter: str = "") -> 
         filter: Optional server-side filter expression (e.g. 'active=true')
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
         return _json(
             await licensees.list_licensees(
                 product_number,
                 filter_str=filter or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -746,7 +879,10 @@ async def netlicensing_get_licensee(licensee_number: str) -> str:
         licensee_number: Licensee identifier (e.g. 'I001')
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
         return _json(await licensees.get_licensee(licensee_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -771,6 +907,9 @@ async def netlicensing_create_licensee(
         licensee_secret: Secret for licensee identification (when product licenseeSecretMode is PREDEFINED)
     """
     try:
+        product_number = v.identifier(product_number, "product_number")
+        if number:
+            number = v.identifier(number, "number")
         return _json(
             await licensees.create_licensee(
                 product_number,
@@ -781,6 +920,8 @@ async def netlicensing_create_licensee(
                 licensee_secret=licensee_secret or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -803,6 +944,7 @@ async def netlicensing_update_licensee(
         licensee_secret: Secret for licensee identification (leave empty to keep current)
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
         return _json(
             await licensees.update_licensee(
                 licensee_number,
@@ -812,6 +954,8 @@ async def netlicensing_update_licensee(
                 licensee_secret=licensee_secret or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -825,7 +969,10 @@ async def netlicensing_delete_licensee(licensee_number: str, force_cascade: bool
         force_cascade: Also delete all dependent licenses
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
         return await licensees.delete_licensee(licensee_number, force_cascade)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -854,6 +1001,13 @@ async def netlicensing_validate_licensee(
         node_secret: NodeLocked model — unique device/node secret
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
+        if product_number:
+            product_number = v.identifier(product_number, "product_number")
+        if product_module_number:
+            product_module_number = v.identifier(product_module_number, "product_module_number")
+        if action:
+            action = v.floating_action(action)
         return _json(
             await licensees.validate_licensee(
                 licensee_number,
@@ -865,6 +1019,8 @@ async def netlicensing_validate_licensee(
                 node_secret=node_secret or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -881,12 +1037,16 @@ async def netlicensing_transfer_licenses(
         to_licensee_number: Destination licensee
     """
     try:
+        from_licensee_number = v.identifier(from_licensee_number, "from_licensee_number")
+        to_licensee_number = v.identifier(to_licensee_number, "to_licensee_number")
         return _json(
             await licensees.transfer_licenses(
                 from_licensee_number,
                 to_licensee_number,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -905,12 +1065,15 @@ async def netlicensing_list_licenses(licensee_number: str, filter: str = "") -> 
         filter: Optional server-side filter expression (e.g. 'active=true')
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
         return _json(
             await licenses.list_licenses(
                 licensee_number,
                 filter_str=filter or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -923,7 +1086,10 @@ async def netlicensing_get_license(license_number: str) -> str:
         license_number: License identifier
     """
     try:
+        license_number = v.identifier(license_number, "license_number")
         return _json(await licenses.get_license(license_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -962,6 +1128,16 @@ async def netlicensing_create_license(
         hidden: Hide license from end customer in Shop (omit to inherit)
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
+        license_template_number = v.identifier(license_template_number, "license_template_number")
+        if number:
+            number = v.identifier(number, "number")
+        if start_date:
+            start_date = v.iso_datetime(start_date, "start_date")
+        if price is not None:
+            v.non_negative_number(price, "price")
+        normalized_currency = v.currency(currency) if currency else None
+        normalized_period = v.time_volume_period(time_volume_period) if time_volume_period else None
         return _json(
             await licenses.create_license(
                 licensee_number,
@@ -971,14 +1147,16 @@ async def netlicensing_create_license(
                 name=name or None,
                 start_date=start_date or None,
                 price=price,
-                currency=currency or None,
+                currency=normalized_currency,
                 time_volume=time_volume or None,
-                time_volume_period=time_volume_period or None,
+                time_volume_period=normalized_period,
                 quantity=quantity or None,
                 parent_feature=parent_feature or None,
                 hidden=hidden,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1015,6 +1193,13 @@ async def netlicensing_update_license(
         hidden: Visibility in Shop (omit to keep current)
     """
     try:
+        license_number = v.identifier(license_number, "license_number")
+        if start_date:
+            start_date = v.iso_datetime(start_date, "start_date")
+        if price is not None:
+            v.non_negative_number(price, "price")
+        normalized_currency = v.currency(currency) if currency else None
+        normalized_period = v.time_volume_period(time_volume_period) if time_volume_period else None
         return _json(
             await licenses.update_license(
                 license_number,
@@ -1022,15 +1207,17 @@ async def netlicensing_update_license(
                 name=name or None,
                 start_date=start_date or None,
                 price=price,
-                currency=currency or None,
+                currency=normalized_currency,
                 time_volume=time_volume or None,
-                time_volume_period=time_volume_period or None,
+                time_volume_period=normalized_period,
                 quantity=quantity or None,
                 used_quantity=used_quantity or None,
                 parent_feature=parent_feature or None,
                 hidden=hidden,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1044,7 +1231,10 @@ async def netlicensing_delete_license(license_number: str, force_cascade: bool =
         force_cascade: Force deletion even if dependencies exist
     """
     try:
+        license_number = v.identifier(license_number, "license_number")
         return await licenses.delete_license(license_number, force_cascade)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1075,7 +1265,10 @@ async def netlicensing_get_token(token_number: str) -> str:
         token_number: Token identifier
     """
     try:
+        token_number = v.identifier(token_number, "token_number")
         return _json(await tokens.get_token(token_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1102,6 +1295,13 @@ async def netlicensing_create_shop_token(
         cancel_url_title: Optional button/link label for cancel redirect
     """
     try:
+        licensee_number = v.identifier(licensee_number, "licensee_number")
+        if product_number:
+            product_number = v.identifier(product_number, "product_number")
+        if license_template_number:
+            license_template_number = v.identifier(
+                license_template_number, "license_template_number"
+            )
         return _json(
             await tokens.create_shop_token(
                 licensee_number,
@@ -1113,6 +1313,8 @@ async def netlicensing_create_shop_token(
                 cancel_url_title=cancel_url_title or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1130,7 +1332,12 @@ async def netlicensing_create_api_token(
         licensee_number: Optional — scope token to a specific licensee
     """
     try:
+        api_key_role = v.api_key_role(api_key_role)
+        if licensee_number:
+            licensee_number = v.identifier(licensee_number, "licensee_number")
         return _json(await tokens.create_api_token(api_key_role, licensee_number or None))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1143,7 +1350,10 @@ async def netlicensing_delete_token(token_number: str) -> str:
         token_number: Token to revoke
     """
     try:
+        token_number = v.identifier(token_number, "token_number")
         return await tokens.delete_token(token_number)
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1178,7 +1388,10 @@ async def netlicensing_get_transaction(transaction_number: str) -> str:
         transaction_number: Transaction identifier
     """
     try:
+        transaction_number = v.identifier(transaction_number, "transaction_number")
         return _json(await transactions.get_transaction(transaction_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1209,6 +1422,18 @@ async def netlicensing_create_transaction(
         payment_method: Optional payment method number
     """
     try:
+        status = v.transaction_status(status)
+        source = v.transaction_source(source)
+        if licensee_number:
+            licensee_number = v.identifier(licensee_number, "licensee_number")
+        if number:
+            number = v.identifier(number, "number")
+        if date_created:
+            date_created = v.iso_datetime(date_created, "date_created")
+        if date_closed:
+            date_closed = v.iso_datetime(date_closed, "date_closed")
+        if payment_method:
+            payment_method = v.identifier(payment_method, "payment_method")
         return _json(
             await transactions.create_transaction(
                 status,
@@ -1222,6 +1447,8 @@ async def netlicensing_create_transaction(
                 payment_method=payment_method or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1246,16 +1473,24 @@ async def netlicensing_update_transaction(
         payment_method: Payment method number (leave empty to keep current)
     """
     try:
+        transaction_number = v.identifier(transaction_number, "transaction_number")
+        normalized_status = v.transaction_status(status) if status else None
+        if date_closed:
+            date_closed = v.iso_datetime(date_closed, "date_closed")
+        if payment_method:
+            payment_method = v.identifier(payment_method, "payment_method")
         return _json(
             await transactions.update_transaction(
                 transaction_number,
-                status=status or None,
+                status=normalized_status,
                 active=active,
                 name=name or None,
                 date_closed=date_closed or None,
                 payment_method=payment_method or None,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1290,7 +1525,10 @@ async def netlicensing_get_payment_method(payment_method_number: str) -> str:
         payment_method_number: Payment method identifier
     """
     try:
+        payment_method_number = v.identifier(payment_method_number, "payment_method_number")
         return _json(await payment_methods.get_payment_method(payment_method_number))
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 
@@ -1309,13 +1547,17 @@ async def netlicensing_update_payment_method(
         paypal_subject: PayPal account e-mail address
     """
     try:
+        payment_method_number = v.identifier(payment_method_number, "payment_method_number")
+        normalized_paypal = v.email(paypal_subject, "paypal_subject") if paypal_subject else None
         return _json(
             await payment_methods.update_payment_method(
                 payment_method_number,
                 active=active,
-                paypal_subject=paypal_subject or None,
+                paypal_subject=normalized_paypal,
             )
         )
+    except ValidationError as exc:
+        return _validation_error(exc)
     except NetLicensingError as exc:
         return _error(exc)
 

--- a/src/netlicensing_mcp/validation.py
+++ b/src/netlicensing_mcp/validation.py
@@ -1,0 +1,205 @@
+"""
+Input validation helpers for NetLicensing MCP tools.
+
+These validators run at the tool boundary (before any HTTP call) so invalid
+input is rejected with a short, actionable message instead of a raw 4xx from
+the upstream API. Each validator returns the trimmed/normalized value on
+success and raises :class:`ValidationError` on failure.
+
+Validators are permissive by design: they catch obvious mistakes (wrong enum
+value, malformed e-mail, non-ISO date) without duplicating NetLicensing's
+business rules.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+# ── Exception ────────────────────────────────────────────────────────────────
+
+
+class ValidationError(ValueError):
+    """Raised when a tool argument fails client-side validation."""
+
+    def __init__(self, field: str, message: str) -> None:
+        self.field = field
+        self.message = message
+        super().__init__(f"Invalid {field}: {message}")
+
+
+# ── Enum reference data (kept in sync with server.py instructions) ───────────
+
+LICENSE_TYPES: frozenset[str] = frozenset({"FEATURE", "TIMEVOLUME", "FLOATING", "QUANTITY"})
+
+LICENSING_MODELS: frozenset[str] = frozenset(
+    {
+        "TryAndBuy",
+        "Subscription",
+        "Rental",
+        "Floating",
+        "MultiFeature",
+        "PayPerUse",
+        "PricingTable",
+        "Quota",
+        "NodeLocked",
+    }
+)
+
+TIME_VOLUME_PERIODS: frozenset[str] = frozenset({"DAY", "WEEK", "MONTH", "YEAR"})
+
+VAT_MODES: frozenset[str] = frozenset({"GROSS", "NET"})
+
+LICENSEE_SECRET_MODES: frozenset[str] = frozenset({"DISABLED", "PREDEFINED", "CLIENT"})
+
+NODE_SECRET_MODES: frozenset[str] = frozenset({"PREDEFINED", "CLIENT"})
+
+TRANSACTION_STATUSES: frozenset[str] = frozenset({"CANCELLED", "CLOSED", "PENDING"})
+
+TRANSACTION_SOURCES: frozenset[str] = frozenset({"SHOP", "AUTO"})
+
+API_KEY_ROLES: frozenset[str] = frozenset(
+    {
+        "ROLE_APIKEY_LICENSEE",
+        "ROLE_APIKEY_ANALYTICS",
+        "ROLE_APIKEY_OPERATION",
+        "ROLE_APIKEY_MAINTENANCE",
+        "ROLE_APIKEY_ADMIN",
+    }
+)
+
+FLOATING_ACTIONS: frozenset[str] = frozenset({"checkOut", "checkIn"})
+
+
+# ── Primitives ───────────────────────────────────────────────────────────────
+
+# Per NetLicensing: identifier must be non-empty, printable, no whitespace
+# or forward slashes (which would break URL paths).
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]{0,63}$")
+
+# RFC 5322-lite: covers the overwhelming majority of real addresses.
+_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+_CURRENCY_RE = re.compile(r"^[A-Z]{3}$")
+
+
+def identifier(value: str, field: str) -> str:
+    """Validate a NetLicensing resource identifier (product_number, etc.)."""
+    if not isinstance(value, str):
+        raise ValidationError(field, "must be a string")
+    stripped = value.strip()
+    if not stripped:
+        raise ValidationError(field, "must not be empty")
+    if not _IDENTIFIER_RE.match(stripped):
+        raise ValidationError(
+            field,
+            "must be 1-64 chars, alphanumeric with '_', '.', or '-' (no whitespace or slashes)",
+        )
+    return stripped
+
+
+def email(value: str, field: str) -> str:
+    """Validate an e-mail address."""
+    if not isinstance(value, str):
+        raise ValidationError(field, "must be a string")
+    stripped = value.strip()
+    if not _EMAIL_RE.match(stripped):
+        raise ValidationError(field, "is not a valid e-mail address")
+    return stripped
+
+
+def currency(value: str, field: str = "currency") -> str:
+    """Validate an ISO 4217 currency code (3 uppercase letters)."""
+    if not isinstance(value, str):
+        raise ValidationError(field, "must be a string")
+    stripped = value.strip().upper()
+    if not _CURRENCY_RE.match(stripped):
+        raise ValidationError(field, "must be a 3-letter ISO 4217 currency code (e.g. EUR, USD)")
+    return stripped
+
+
+def iso_datetime(value: str, field: str) -> str:
+    """Validate an ISO-8601 datetime string; returns it unchanged."""
+    if not isinstance(value, str):
+        raise ValidationError(field, "must be a string")
+    stripped = value.strip()
+    try:
+        # Accept "Z" as an alias for "+00:00".
+        datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(field, f"is not a valid ISO-8601 datetime ({exc})") from exc
+    return stripped
+
+
+def positive_int(value: int, field: str, *, allow_zero: bool = False) -> int:
+    """Validate a positive integer (or >= 0 when allow_zero=True)."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError(field, "must be an integer")
+    if allow_zero and value < 0:
+        raise ValidationError(field, "must be >= 0")
+    if not allow_zero and value <= 0:
+        raise ValidationError(field, "must be > 0")
+    return value
+
+
+def non_negative_number(value: float | int, field: str) -> float:
+    """Validate a non-negative price/amount."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(field, "must be a number")
+    if value < 0:
+        raise ValidationError(field, "must be >= 0")
+    return float(value)
+
+
+def one_of(value: str, allowed: frozenset[str], field: str) -> str:
+    """Validate that *value* is in *allowed* (case-sensitive)."""
+    if not isinstance(value, str):
+        raise ValidationError(field, "must be a string")
+    stripped = value.strip()
+    if stripped not in allowed:
+        allowed_sorted = ", ".join(sorted(allowed))
+        raise ValidationError(field, f"must be one of: {allowed_sorted}")
+    return stripped
+
+
+# ── Convenience wrappers ────────────────────────────────────────────────────
+
+
+def license_type(value: str, field: str = "license_type") -> str:
+    return one_of(value, LICENSE_TYPES, field)
+
+
+def licensing_model(value: str, field: str = "licensing_model") -> str:
+    return one_of(value, LICENSING_MODELS, field)
+
+
+def time_volume_period(value: str, field: str = "time_volume_period") -> str:
+    return one_of(value, TIME_VOLUME_PERIODS, field)
+
+
+def vat_mode(value: str, field: str = "vat_mode") -> str:
+    return one_of(value, VAT_MODES, field)
+
+
+def licensee_secret_mode(value: str, field: str = "licensee_secret_mode") -> str:
+    return one_of(value, LICENSEE_SECRET_MODES, field)
+
+
+def node_secret_mode(value: str, field: str = "node_secret_mode") -> str:
+    return one_of(value, NODE_SECRET_MODES, field)
+
+
+def transaction_status(value: str, field: str = "status") -> str:
+    return one_of(value, TRANSACTION_STATUSES, field)
+
+
+def transaction_source(value: str, field: str = "source") -> str:
+    return one_of(value, TRANSACTION_SOURCES, field)
+
+
+def api_key_role(value: str, field: str = "api_key_role") -> str:
+    return one_of(value, API_KEY_ROLES, field)
+
+
+def floating_action(value: str, field: str = "action") -> str:
+    return one_of(value, FLOATING_ACTIONS, field)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,168 @@
+"""Tests for the input validation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from netlicensing_mcp import validation as v
+from netlicensing_mcp.validation import ValidationError
+
+
+# ── identifier ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["P001", "product-1", "module_42", "A.b.c", "X" * 64],
+)
+def test_identifier_accepts_valid(value: str) -> None:
+    assert v.identifier(value, "field") == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", " ", "has space", "slash/inside", "with\nnewline", "X" * 65, "-leadingdash"],
+)
+def test_identifier_rejects_invalid(value: str) -> None:
+    with pytest.raises(ValidationError):
+        v.identifier(value, "field")
+
+
+def test_identifier_trims_whitespace() -> None:
+    assert v.identifier("  P001  ", "field") == "P001"
+
+
+# ── email ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["a@b.co", "alice.smith+tag@example.com"])
+def test_email_accepts_valid(value: str) -> None:
+    assert v.email(value, "paypal_subject") == value
+
+
+@pytest.mark.parametrize("value", ["no-at-sign", "x@y", "a @b.c", "@b.c", "a@"])
+def test_email_rejects_invalid(value: str) -> None:
+    with pytest.raises(ValidationError):
+        v.email(value, "paypal_subject")
+
+
+# ── currency ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["EUR", "USD", "gbp"])
+def test_currency_accepts_valid(value: str) -> None:
+    assert v.currency(value) == value.upper()
+
+
+@pytest.mark.parametrize("value", ["E", "EUROS", "123", ""])
+def test_currency_rejects_invalid(value: str) -> None:
+    with pytest.raises(ValidationError):
+        v.currency(value)
+
+
+# ── iso_datetime ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-04-17",
+        "2026-04-17T12:00:00",
+        "2026-04-17T12:00:00+02:00",
+        "2026-04-17T12:00:00Z",
+    ],
+)
+def test_iso_datetime_accepts_valid(value: str) -> None:
+    assert v.iso_datetime(value, "start_date") == value
+
+
+@pytest.mark.parametrize("value", ["yesterday", "17/04/2026", "not-a-date"])
+def test_iso_datetime_rejects_invalid(value: str) -> None:
+    with pytest.raises(ValidationError):
+        v.iso_datetime(value, "start_date")
+
+
+# ── positive_int ────────────────────────────────────────────────────────────
+
+
+def test_positive_int_accepts_positive() -> None:
+    assert v.positive_int(5, "qty") == 5
+
+
+def test_positive_int_allow_zero() -> None:
+    assert v.positive_int(0, "qty", allow_zero=True) == 0
+
+
+def test_positive_int_rejects_zero_by_default() -> None:
+    with pytest.raises(ValidationError):
+        v.positive_int(0, "qty")
+
+
+def test_positive_int_rejects_negative() -> None:
+    with pytest.raises(ValidationError):
+        v.positive_int(-1, "qty", allow_zero=True)
+
+
+def test_positive_int_rejects_bool() -> None:
+    # booleans subclass int — make sure we don't silently accept True/False.
+    with pytest.raises(ValidationError):
+        v.positive_int(True, "qty")  # type: ignore[arg-type]
+
+
+# ── non_negative_number ─────────────────────────────────────────────────────
+
+
+def test_non_negative_number_accepts_zero_and_float() -> None:
+    assert v.non_negative_number(0, "price") == 0.0
+    assert v.non_negative_number(9.99, "price") == 9.99
+
+
+def test_non_negative_number_rejects_negative() -> None:
+    with pytest.raises(ValidationError):
+        v.non_negative_number(-1, "price")
+
+
+# ── enum wrappers ───────────────────────────────────────────────────────────
+
+
+def test_license_type_accepts_valid() -> None:
+    assert v.license_type("FEATURE") == "FEATURE"
+
+
+def test_license_type_rejects_invalid() -> None:
+    with pytest.raises(ValidationError) as exc:
+        v.license_type("feature")  # case-sensitive
+    assert "FEATURE" in str(exc.value)
+
+
+def test_licensing_model_accepts_valid() -> None:
+    assert v.licensing_model("Subscription") == "Subscription"
+
+
+def test_licensing_model_rejects_unknown() -> None:
+    with pytest.raises(ValidationError):
+        v.licensing_model("PerpetualLicense")
+
+
+def test_api_key_role_accepts_valid() -> None:
+    assert v.api_key_role("ROLE_APIKEY_ADMIN") == "ROLE_APIKEY_ADMIN"
+
+
+def test_floating_action_accepts_valid() -> None:
+    assert v.floating_action("checkOut") == "checkOut"
+    assert v.floating_action("checkIn") == "checkIn"
+
+
+def test_transaction_status_rejects_invalid() -> None:
+    with pytest.raises(ValidationError):
+        v.transaction_status("OPEN")
+
+
+# ── Error shape ─────────────────────────────────────────────────────────────
+
+
+def test_validation_error_exposes_field_and_message() -> None:
+    exc = ValidationError("product_number", "must not be empty")
+    assert exc.field == "product_number"
+    assert exc.message == "must not be empty"
+    assert "product_number" in str(exc)


### PR DESCRIPTION
## Summary

- Reject malformed identifiers, emails, currency codes, ISO-8601 dates, and enum values (license types, licensing models, VAT/secret modes, transaction statuses, API-key roles, floating actions) at the MCP tool boundary. Users get a structured `{error, validation: true, field, detail}` JSON response instead of a raw 4xx from NetLicensing.
- Add `.pre-commit-config.yaml` with ruff, mypy, and sanity hooks (merge-conflict markers, large files, private keys).
- Add a baseline `[tool.mypy]` section to `pyproject.toml`. Baseline is loose on purpose — raising to strict surfaces 47 pre-existing `dict` / untyped-def issues in tool wrappers and deserves a separate cleanup pass.
- Expose `NETLICENSING_HTTP_TIMEOUT` and `NETLICENSING_HTTP_CONNECT_TIMEOUT` env vars to override httpx timeouts (previously hard-coded at 30s / 10s).
- Add `CHANGELOG.md` (Keep-a-Changelog format).
- Add 49 tests for the validation module (`tests/test_validation.py`).

## Why

Today an empty `product_number`, `FEATURE` typed as `feature`, or `2026/04/17` as a start date all produce opaque HTTP errors after a round-trip to go.netlicensing.io. Validating at the tool boundary gives users (and the LLM driving them) an immediately actionable message — faster feedback, fewer wasted calls, and a clear `field` key to correct.

The rest of the changes are low-risk hygiene: pre-commit keeps CI green locally, env-var timeouts unblock slower networks / VPN users, and CHANGELOG is a conventional addition that costs nothing.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check` — clean (20/20)
- [x] `mypy src/` — no issues (17 files)
- [x] `pytest -q` — **131 passed** (82 pre-existing + 49 new validation tests)
- [ ] Smoke test against a real NetLicensing account to confirm valid inputs still pass through unchanged
- [ ] Confirm verbose mode (`-v`) still masks the API key

## Follow-ups (not in this PR)

- Raise mypy baseline to strict once tool-wrapper type-args are cleaned up (47 pre-existing issues).
- Expand tool docstrings for richer MCP client introspection.
- Split the 1.5k-line `tests/test_tools.py` into per-module test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)