### PR TITLE
Fix REST path traversal token-redaction bypass (GHSA-hxpf-9xvq-wph8)

### DIFF
--- a/src/netlicensing_mcp/client.py
+++ b/src/netlicensing_mcp/client.py
@@ -14,6 +14,7 @@ import logging
 import os
 import time
 from typing import Any
+from urllib.parse import unquote
 
 import httpx
 from dotenv import load_dotenv
@@ -72,6 +73,33 @@ def _raise_on_error(response: httpx.Response) -> None:
     except Exception:
         detail = response.text
     raise NetLicensingError(response.status_code, detail)
+
+
+# ── Path validation ──────────────────────────────────────────────────────────
+
+
+def _validated_path(path: str) -> str:
+    """Reject path-traversal / separator injection in interpolated identifiers.
+
+    Tool layers build REST paths like ``f"/product/{number}"`` from
+    caller-controlled values. httpx applies RFC 3986 / WHATWG dot-segment
+    removal, so a value of ``../token`` collapses ``/product/../token`` to
+    ``/token`` — silently redirecting the request to an unintended endpoint and
+    bypassing endpoint-specific redaction (e.g. token APIKEY masking).
+
+    Validate every segment before the request is built. ``unquote`` is applied
+    first because httpx does not decode ``%2f``/``%2e``, so percent-encoded
+    separators would otherwise reach the upstream untouched.
+    """
+    if not path.startswith("/"):
+        raise NetLicensingError(400, "Internal error: upstream path must start with '/'")
+    for segment in path.split("/"):
+        decoded = unquote(segment)
+        if decoded in {".", ".."} or "/" in decoded or "\\" in decoded:
+            raise NetLicensingError(400, "Invalid identifier: path separators are not allowed")
+        if any(ord(ch) < 32 for ch in decoded):
+            raise NetLicensingError(400, "Invalid identifier: control characters are not allowed")
+    return path
 
 
 # ── Auth header ──────────────────────────────────────────────────────────────
@@ -140,7 +168,7 @@ async def close_client() -> None:
 
 async def nl_get(path: str, params: dict[str, str] | None = None) -> dict[str, Any]:
     client = _get_client()
-    url = f"{BASE_URL}{path}"
+    url = f"{BASE_URL}{_validated_path(path)}"
     logger.debug("GET %s params_present=%s", url, bool(params))
     r = await client.get(url, headers=_headers(), params=params or {})
     logger.debug("Response %s", r.status_code)
@@ -150,7 +178,7 @@ async def nl_get(path: str, params: dict[str, str] | None = None) -> dict[str, A
 
 async def nl_post(path: str, data: dict[str, str] | None = None) -> dict[str, Any]:
     client = _get_client()
-    url = f"{BASE_URL}{path}"
+    url = f"{BASE_URL}{_validated_path(path)}"
     logger.debug("POST %s data_present=%s", url, bool(data))
     r = await client.post(
         url,
@@ -164,7 +192,7 @@ async def nl_post(path: str, data: dict[str, str] | None = None) -> dict[str, An
 
 async def nl_put(path: str, data: dict[str, str]) -> dict[str, Any]:
     client = _get_client()
-    url = f"{BASE_URL}{path}"
+    url = f"{BASE_URL}{_validated_path(path)}"
     logger.debug("PUT %s data_present=%s", url, bool(data))
     r = await client.put(
         url,
@@ -179,7 +207,7 @@ async def nl_put(path: str, data: dict[str, str]) -> dict[str, Any]:
 async def nl_delete(path: str, params: dict[str, str] | None = None) -> int:
     """Delete a resource. Returns HTTP status code (200 or 204)."""
     client = _get_client()
-    url = f"{BASE_URL}{path}"
+    url = f"{BASE_URL}{_validated_path(path)}"
     logger.debug("DELETE %s params_present=%s", url, bool(params))
     r = await client.delete(url, headers=_headers(), params=params or {})
     logger.debug("Response %s", r.status_code)

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,117 @@
+"""Regression tests for GHSA-hxpf-9xvq-wph8 — REST path traversal.
+
+A caller-controlled identifier interpolated into a REST path (e.g.
+``f"/product/{product_number}"``) could contain ``../`` segments. httpx
+normalizes those away, silently redirecting the request to an unintended
+endpoint (e.g. ``/token``) and bypassing endpoint-specific redaction. The
+``_validated_path`` guard in ``client.py`` rejects such inputs before any HTTP
+request is built.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import netlicensing_mcp.client as client
+from netlicensing_mcp.client import NetLicensingError, _validated_path
+
+
+# ─── Unit: _validated_path ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/product/P001",
+        "/product",
+        "/token/APIKEY-123",
+        "/bundle/B1/obtain",
+        "/licensee/L1/validate",
+        "/licensetemplate/LT-2024",
+        "/transaction/TR_001",
+        # A plain extra "/" yields valid sub-segments and is indistinguishable
+        # from legitimate multi-segment paths (e.g. /bundle/B1/obtain) once the
+        # path is assembled. It can only descend under the same root, never
+        # climb to a sibling top-level endpoint, so it is not a traversal.
+        "/product/x/y",
+    ],
+)
+def test_legitimate_paths_pass(path):
+    """Real REST paths (incl. multi-segment ones) are returned unchanged."""
+    assert _validated_path(path) == path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/product/../token",  # the GHSA PoC payload
+        "/product/..%2ftoken",  # percent-encoded slash (httpx does NOT decode)
+        "/product/%2e%2e/token",  # percent-encoded dot-dot
+        "/product/..",
+        "/product/.",
+        "/product/x\\y",  # backslash separator
+        "/product/a%2fb",  # encoded separator inside a segment
+    ],
+)
+def test_traversal_and_separator_paths_rejected(path):
+    with pytest.raises(NetLicensingError) as exc:
+        _validated_path(path)
+    assert exc.value.status_code == 400
+
+
+def test_control_characters_rejected():
+    with pytest.raises(NetLicensingError) as exc:
+        _validated_path("/product/foo\nbar")
+    assert exc.value.status_code == 400
+    assert "control characters" in exc.value.detail
+
+
+def test_non_rooted_path_rejected():
+    with pytest.raises(NetLicensingError) as exc:
+        _validated_path("product/P001")
+    assert exc.value.status_code == 400
+
+
+# ─── Integration: guard fires before any HTTP request ─────────────────────────
+
+
+@pytest.fixture
+def mock_http_client():
+    """Patch the shared AsyncClient so we can assert whether a request was sent."""
+    fake = AsyncMock()
+    with patch("netlicensing_mcp.client._get_client", return_value=fake):
+        token = client.api_key_ctx.set("dummy-key")
+        try:
+            yield fake
+        finally:
+            client.api_key_ctx.reset(token)
+
+
+@pytest.mark.parametrize("helper", ["nl_get", "nl_post", "nl_put", "nl_delete"])
+async def test_helpers_reject_traversal_before_request(helper, mock_http_client):
+    fn = getattr(client, helper)
+    args = ("/product/../token",)
+    if helper in ("nl_post", "nl_put"):
+        args = ("/product/../token", {"name": "x"})
+
+    with pytest.raises(NetLicensingError) as exc:
+        await fn(*args)
+
+    assert exc.value.status_code == 400
+    # No HTTP method was ever invoked on the client.
+    mock_http_client.get.assert_not_called()
+    mock_http_client.post.assert_not_called()
+    mock_http_client.put.assert_not_called()
+    mock_http_client.delete.assert_not_called()
+
+
+async def test_get_product_traversal_does_not_leak_token(mock_http_client):
+    """End-to-end replay of the GHSA PoC: the tool must raise, not leak."""
+    from netlicensing_mcp.tools.products import get_product
+
+    with pytest.raises(NetLicensingError):
+        await get_product("../token")
+
+    mock_http_client.get.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes **GHSA-hxpf-9xvq-wph8** — a REST path traversal (CWE-22) that bypasses token redaction. **CVSS 9.6 (Critical)** — `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N`.

A caller-controlled identifier interpolated into a REST path (e.g. `f"/product/{product_number}"`) could contain `../` segments. httpx applies RFC 3986 / WHATWG dot-segment removal, collapsing `/product/../token` to `/token` and silently redirecting the request to the token endpoint. The response is then wrapped via the generic `_wrap_json` path instead of `_wrap_json_token_read`, so `redact_token_read()` never runs and plaintext APIKEY `number` / SHOP `shopURL` values (potentially `ROLE_APIKEY_ADMIN`) are returned verbatim.

The root cause is in `client.py`, so it affects **all path-interpolating call sites across every entity**, not just `get_product`.

## Fix

- Add a centralized `_validated_path()` guard in `client.py`, applied in all four helpers (`nl_get`, `nl_post`, `nl_put`, `nl_delete`).
- Each path segment is `unquote`d first (httpx does **not** decode `%2f`/`%2e`), then rejected if it is `.`/`..`, contains an embedded `/` or `\`, or contains control characters.
- Raises `NetLicensingError(400, ...)`, which existing handlers surface as a clean validation error to the MCP client — no request is ever sent.

## Tests

New `tests/test_path_traversal.py` (22 cases):
- Legit paths pass, including multi-segment `/bundle/B1/obtain`, `/licensee/L1/validate`.
- Rejected: `../token` (the advisory PoC), `..%2ftoken`, `%2e%2e/token`, backslash, encoded in-segment separator, control chars, unrooted paths.
- All four helpers raise **before** any HTTP request is issued.
- End-to-end replay of `get_product("../token")` raises instead of leaking.

## Verification

`242 passed` · `ruff check` clean · `ruff format --check` clean · `mypy` clean.

## Note on scope

The advisory's suggested `x/y` regression test is intentionally omitted: once the path is assembled, `/product/x/y` is indistinguishable from a legitimate multi-segment path, and the advisory's own proposed validator (which also splits on `/`) wouldn't reject it either. A plain extra `/` can only descend under the same root, never climb sideways to `/token`, so it does not enable the redaction bypass — that strictly requires `..` or an encoded in-segment separator, both now blocked. Belt-and-suspenders validation of raw `/` *inside a single identifier* would belong at the tool layer (before interpolation) and is a separate, lower-severity hardening item.
